### PR TITLE
make server options configureable from lib users

### DIFF
--- a/v2/init.go
+++ b/v2/init.go
@@ -25,8 +25,11 @@ type Server struct {
 	shutdownTimeout time.Duration
 }
 
-func Serve(port string, handler http.Handler) {
-	httpServer := NewHttpServer(handler, Port(port))
+func Serve(port string, handler http.Handler, customOpts ...Option) {
+
+	customOpts = append(customOpts, Port(port))
+
+	httpServer := NewHttpServer(handler, customOpts...)
 
 	// Waiting signal
 	interrupt := make(chan os.Signal, 1)


### PR DESCRIPTION
make http server custom options configureable from the library users code.
for example, users can now specify the WriteTimeout value like this:
```
grace.Serve(config.Port, handler, grace.WriteTimeout(30*time.Second))
```

Previously, configuring such options is possible only for `Port`